### PR TITLE
[fix] 반복 일정 추억 작성 오류

### DIFF
--- a/src/apis/memoryApi.ts
+++ b/src/apis/memoryApi.ts
@@ -38,6 +38,8 @@ export interface CreateMemoryProps {
   pictureId: number;
   placeMemories: CreatePlaceMemoriesProps[];
   scheduleId: number;
+  scheduleName: string;
+  scheduleDate: string;
 }
 
 export interface CreateMemoryReturnProps {

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -74,6 +74,8 @@ export default function Calendar() {
                     calendarType='CALENDAR'
                     calendarPlan={fix}
                     scheduleId={scheduleId}
+                    scheduleName={fix.scheduleResDto.scheduleName}
+                    scheduleDate={fix.scheduleResDto.curDate}
                   >
                     <PlanTitleText>{fix && fix.scheduleResDto.scheduleName}</PlanTitleText>
                     <PlanPlaceText>{fixDate.format('YYYY-MM-DD')}</PlanPlaceText>
@@ -99,6 +101,8 @@ export default function Calendar() {
                     calendarType='CALENDAR'
                     calendarPlan={plan}
                     scheduleId={scheduleId}
+                    scheduleName={plan.scheduleResDto.scheduleName}
+                    scheduleDate={plan.scheduleResDto.curDate}
                   >
                     <PlanTitleText>{plan && plan.scheduleResDto.scheduleName}</PlanTitleText>
                     <PlanPlaceText>{planDate.format('YYYY-MM-DD')}</PlanPlaceText>

--- a/src/app/memory/create/page.tsx
+++ b/src/app/memory/create/page.tsx
@@ -8,6 +8,7 @@ import LabelInput, { LabelInputPropsType } from '@components/atoms/input/LabelIn
 import { MainWrapper } from '@components/atoms/wrapper/MainWrapper';
 import { CreateMemoryProps, createMemoryApi } from 'apis/memoryApi';
 import { uploadImageApi, uploadMultiImageApi } from 'apis/pictureApi';
+import moment from 'moment';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { toast } from 'react-toastify';
@@ -46,6 +47,9 @@ export default function CreateMemoryPage() {
 
   const searchParams = useSearchParams();
   const scheduleId = searchParams.get('scheduleId') ? Number(searchParams.get('scheduleId')) : 1;
+  const scheduleName = searchParams.get('scheduleName') ??  '';
+  const scheduleDate = searchParams.get('scheduleDate') ?? moment().format('YYYY-MM-DD');
+
   console.log(scheduleId);
 
   const useFormReturn = useForm({
@@ -94,6 +98,8 @@ export default function CreateMemoryPage() {
       pictureId: d.pictureId,
       placeMemories: [],
       scheduleId: scheduleId,
+      scheduleName: scheduleName,
+      scheduleDate: scheduleDate
     };
     d.placeMemories.map((place) => {
       data.placeMemories.push({

--- a/src/components/atoms/item/ScheduleItem.tsx
+++ b/src/components/atoms/item/ScheduleItem.tsx
@@ -25,7 +25,9 @@ interface ScheduleItemProps {
   ddayFix?: ScheduleProps;
   calendarPlan?: ScheduleTotalProps;
   ddayPlan?: ScheduleProps;
-  scheduleId?: number | undefined;
+  scheduleId: number | undefined;
+  scheduleName: string;
+  scheduleDate: string;
   children: React.ReactNode;
 }
 
@@ -37,6 +39,8 @@ export const ScheduleItem = ({
   ddayFix,
   ddayPlan,
   scheduleId,
+  scheduleName,
+  scheduleDate,
   children,
 }: ScheduleItemProps) => {
   const fixTargetDate =
@@ -154,7 +158,7 @@ export const ScheduleItem = ({
                     </button>
                   ) : (
                     <button
-                      onClick={() => router.push(`/memory/create?scheduleId=${scheduleId}`)}
+                      onClick={() => router.push(`/memory/create?scheduleId=${scheduleId}&scheduleName=${scheduleName}&scheduleDate=${scheduleDate}`)}
                       className='inline-block bg-[#5CA0FF] text-[20px] text-white ps-[6px] pb-[6px] pe-[4px] pt-[4px] rounded-[8px] hover:bg-[#006BFF] hover:cursor-pointer'
                     >
                       <IoCreateOutline />

--- a/src/components/molecules/scheduleList/DDayScheduleList.tsx
+++ b/src/components/molecules/scheduleList/DDayScheduleList.tsx
@@ -51,6 +51,8 @@ const DDayScheduleList = () => {
               const today = moment().format('YYYY-MM-DD');
               const currentDate = moment(today, 'YYYY-MM-DD');
               const scheduleId = fix.id;
+              const scheduleDate = fix.curDate;
+              const scheduleName = fix.scheduleName;
               if (fixDate.isSame(currentDate) || fixDate.isAfter(currentDate)) {
                 return (
                   <ScheduleItem
@@ -59,6 +61,8 @@ const DDayScheduleList = () => {
                     calendarType='DDAY'
                     ddayFix={fix}
                     scheduleId={scheduleId}
+                    scheduleDate={scheduleDate}
+                    scheduleName={scheduleName}
                   >
                     <PlanTitleText>{fix && fix.scheduleName}</PlanTitleText>
                     <PlanPlaceText>{fixDate.format('YYYY-MM-DD')}</PlanPlaceText>
@@ -74,6 +78,8 @@ const DDayScheduleList = () => {
               const today = moment().format('YYYY-MM-DD');
               const currentDate = moment(today, 'YYYY-MM-DD');
               const scheduleId = plan.id;
+              const scheduleDate = plan.curDate;
+              const scheduleName = plan.scheduleName;
               if (planDate.isSame(currentDate) || planDate.isAfter(currentDate)) {
                 return (
                   <ScheduleItem
@@ -82,6 +88,8 @@ const DDayScheduleList = () => {
                     calendarType='DDAY'
                     ddayPlan={plan}
                     scheduleId={scheduleId}
+                    scheduleDate={scheduleDate}
+                    scheduleName={scheduleName}
                   >
                     <PlanTitleText>{plan && plan.scheduleName}</PlanTitleText>
                     <PlanPlaceText>{planDate.format('YYYY-MM-DD')}</PlanPlaceText>


### PR DESCRIPTION
- 반복 일정에 대해 추억 작성시 해당 날짜의 추억이 모든 반복 일정에 대해 공유되는 문제
- 특정 날짜에 대한 추억임을 표시하기 위해 특정 날짜와 그 당시의 일정 이름 추가하여 API  호출하도록 변경
- 추후, 변수 이름에 대한 정리 필요 (curDate, scheduleDate 등등)

VVUE-57